### PR TITLE
Specify to use Vue 2.6.12

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <title>Project Kyaru</title>
     <link rel="shortcut icon" type="image/x-icon" href="107831.ico" />
-    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
     <!--script data-ad-client="ca-pub-8278251579038034" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script-->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css">
 

--- a/qd/index.html
+++ b/qd/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <title>PCR 渠道服公会战排名查询</title>
     <link rel="shortcut icon" type="image/x-icon" href="../107831.ico" />
-    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
     <!--script data-ad-client="ca-pub-8278251579038034" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script-->
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-5KD1B4TGX3"></script>

--- a/tw/index.html
+++ b/tw/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <title>PCR 台服公会战排名查询</title>
     <link rel="shortcut icon" type="image/x-icon" href="../107831.ico" />
-    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.12"></script>
     <!--script data-ad-client="ca-pub-8278251579038034" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script-->
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-5KD1B4TGX3"></script>


### PR DESCRIPTION
It seems that original CDN for Vue (https://cdn.jsdelivr.net/npm/vue) becomes Vue 3, which is not work for this webpage (Vue 2 is requred). This pull request change it to use Vue 2.6.12.